### PR TITLE
Reorganize nlp tools

### DIFF
--- a/cli/Runner.py
+++ b/cli/Runner.py
@@ -1,4 +1,4 @@
-from parse import Parser
+from nlp import Parser
 
 class Runner(object):
     """

--- a/nlp/Parser.py
+++ b/nlp/Parser.py
@@ -1,0 +1,18 @@
+from nltk.parse.stanford import StanfordParser
+from Config import Config
+
+class Parser(object):
+    """
+    Parse and analyze sentence structure
+    """
+    def __init__(self):
+        config = Config()
+
+        jar_path = config.get("PATHS", "stanford_jar")
+        stanford_models_jar = config.get("PATHS", "stanford_models_jar")
+
+        self.parser = StanfordParser(jar_path, stanford_models_jar)
+
+
+    def parse(self, statement):
+        return list(self.parser.raw_parse(statement))

--- a/nlp/Tagger.py
+++ b/nlp/Tagger.py
@@ -1,17 +1,15 @@
 from nltk.tokenize.stanford import StanfordTokenizer
 from nltk.tag.stanford import StanfordPOSTagger, StanfordNERTagger
-from nltk.parse.stanford import StanfordParser
 from Config import Config
 
-class Parser(object):
+class Tagger(object):
     """
-    Parse and analyze sentence structure
+    Tokenize and tag sentence
     """
     def __init__(self):
         config = Config()
 
         jar_path = config.get("PATHS", "stanford_jar")
-        stanford_models_jar = config.get("PATHS", "stanford_models_jar")
         stanford_models = config.get("PATHS", "stanford_models")
 
         pos_model_path = "%s/pos-tagger/english-left3words/english-left3words-distsim.tagger" % stanford_models
@@ -22,18 +20,16 @@ class Parser(object):
         self.pos_tagger = StanfordPOSTagger(pos_model_path, jar_path)
         self.ner_tagger = StanfordNERTagger(ner_model_path, jar_path)
 
-        self.parser = StanfordParser(jar_path, stanford_models_jar)
+
+    def tokenize(self, statement):
+        return self.tokenizer.tokenize(statement)
 
 
     def tag(self, statement):
-        tokens = self.tokenizer.tokenize(statement)
+        tokens = self.tokenize(statement)
         return self.pos_tagger.tag(tokens)
 
 
     def ner(self, statement):
-        tokens = self.tokenizer.tokenize(statement)
+        tokens = self.tokenize(statement)
         return self.ner_tagger.tag(tokens)
-
-
-    def parse(self, statement):
-        return list(self.parser.raw_parse(statement))

--- a/nlp/__init__.py
+++ b/nlp/__init__.py
@@ -1,0 +1,2 @@
+from nlp.Parser import Parser
+from nlp.Tagger import Tagger

--- a/parse/__init__.py
+++ b/parse/__init__.py
@@ -1,1 +1,0 @@
-from parse.Parser import Parser


### PR DESCRIPTION
Renaming the `parse` folder to `nlp`. This makes it more general and we can put other files related to any nlp tools into this folder (`Classifier`, `NeuralNetwork`, etc).

I also split out parsing and tagging to be separate. 