### PR TITLE
Refactor doc['tagged'] into dictionary

### DIFF
--- a/cli/Runner.py
+++ b/cli/Runner.py
@@ -56,5 +56,5 @@ class Runner(object):
         return {
             'text': statement,
             'tokens': self.tokenizer(statement),
-            'tagged': []
+            'tagged': {}
         }

--- a/nlp/DBCorpusClassifier.py
+++ b/nlp/DBCorpusClassifier.py
@@ -17,8 +17,13 @@ class DBCorpusClassifier(object):
         trees = [tree.leaves() for tree in doc['parse'].subtrees(self.filter_tree)]
         tokens = [token for leaves in trees for token in leaves if token not in doc['tagged']]
 
-        doc['db_corpus'] = self.classify(tokens)
-        doc['tagged'] += [match[0] for match in doc['db_corpus']]
+        tags = self.classify(tokens)
+        
+        for tag in tags:
+            doc['tagged'][tag[0]] = {
+                'type': 'corpus',
+                'tags': tag[1]
+            }
 
 
     @staticmethod

--- a/nlp/DBSchemaClassifier.py
+++ b/nlp/DBSchemaClassifier.py
@@ -15,8 +15,13 @@ class DBSchemaClassifier(object):
         trees = [tree.leaves() for tree in doc['parse'].subtrees(self.filter_tree)]
         tokens = [token for leaves in trees for token in leaves if token not in doc['tagged']]
 
-        doc['db_schema'] = [match for match in self.find_db_matches(tokens) if match[1]]
-        doc['tagged'] += [match[0] for match in doc['db_schema']]
+        matches = [match for match in self.find_db_matches(tokens) if match[1]]
+
+        for match in matches:
+            doc['tagged'][match[0]] = {
+                'type': 'schema',
+                'tags': match[1]
+            }
 
 
     def find_db_matches(self, tokens, cutoff=.8, table=''):


### PR DESCRIPTION
Turn `doc['tagged']` from a list into a dictionary.

The keys are the tokens that are tagged. Values are another dictionary with a `type` and the `tags`. `Type` is there for now in case we need it when generating the nodes. It can always be removed later.

For the db schema and db corpus, the `tags` are a list of tuples which include the table name or column name and the probability.

Example:
How many sections are named Constitutional Law?

```python
tagged:
{
  'Constitutional': {
    'type': 'corpus',
    'tags': [('sections.name', 0.90083076561245601), ('courses.name', 0.028788241096417588),('students.first_name', 0.013862120634624227)]
  },
  'Law': {
    'type': 'corpus',
    'tags': [('sections.name', 0.76726069554337728), ('courses.name', 0.08380179972233516), ('students.first_name', 0.028386901422755854)]
  },
  'sections': {
    'type': 'schema',
    'tags': [('sections', 1.0), ('registrations.section_id', 0.8819171036881969), ('sections.description', 0.8366600265340756)]
  }
}
```