### PR TITLE
Add unigram tagger for sql grammar

### DIFF
--- a/cli/Runner.py
+++ b/cli/Runner.py
@@ -1,7 +1,7 @@
 from Config import Config
 from communicate import Communicator
 from database import SchemaGraph
-from nlp import DBCorpusClassifier, DBSchemaClassifier, Parser, Tokenizer
+from nlp import DBCorpusClassifier, DBSchemaClassifier, SQLGrammarClassifier, Parser, Tokenizer
 
 class Runner(object):
     """
@@ -19,10 +19,11 @@ class Runner(object):
         self.tokenizer = Tokenizer(paths['stanford_jar'])
 
         parser = Parser(paths['stanford_jar'], paths['stanford_models_jar'])
+        grammar_classifier = SQLGrammarClassifier(models['sql_model'])
         corpus_classifier = DBCorpusClassifier(models['db_model'])
         schema_classifier = DBSchemaClassifier(schema_graph)
 
-        self.pipeline = [parser, schema_classifier, corpus_classifier]
+        self.pipeline = [parser, grammar_classifier, schema_classifier, corpus_classifier]
 
 
     def start(self):
@@ -44,10 +45,11 @@ class Runner(object):
             for process in self.pipeline:
                 process(doc)
 
-            for key, value in doc.iteritems():
-                print "%s: " % key
-                print value
-                print
+            for key, value in doc['tagged'].iteritems():
+                print key, value
+
+            print
+            print doc['dep_parse'].tree().pretty_print()
 
             self.communicator.resume()
 

--- a/cli/Setup.py
+++ b/cli/Setup.py
@@ -2,7 +2,7 @@ import os
 import nltk
 from Config import Config
 from database import Database, SchemaGraph
-from nlp import DBCorpusGenerator, DBCorpusClassifier
+from nlp import DBCorpusGenerator, DBCorpusClassifier, SQLGrammarClassifier
 
 class Setup(object):
     """
@@ -24,6 +24,7 @@ class Setup(object):
         self.create_db_graph(force)
         self.create_db_corpus(force)
         self.train_db_classifier(force)
+        self.train_sql_classifier(force)
 
         self.config.write()
         self.comm.say("Set up complete.")
@@ -140,3 +141,19 @@ class Setup(object):
         self.config.set("MODELS", "db_model", model_path)
 
         self.comm.say("Database classifier trained.")
+
+
+    def train_sql_classifier(self, force):
+        if not force and self.config.has("MODELS", "sql_model"):
+            self.comm.say("SQL Grammar classifier already trained.")
+            return
+
+        self.comm.say("Training SQL grammar classifier.")
+
+        base_path = self.config.get('PATHS', 'base')
+        model_path = os.path.join(base_path, "sql_model.p")
+
+        SQLGrammarClassifier().train(model_path)
+        self.config.set("MODELS", "sql_model", model_path)
+
+        self.comm.say("SQL grammar classifier trained.")

--- a/nlp/SQLGrammarClassifier.py
+++ b/nlp/SQLGrammarClassifier.py
@@ -1,0 +1,37 @@
+import cPickle as pickle
+from nltk import UnigramTagger, DefaultTagger
+from nlp.SQLGrammarCorpus import CORPUS
+
+class SQLGrammarClassifier(object):
+    def __init__(self, model_path=None):
+        if model_path:
+            with open(model_path, "rb") as model_file:
+                self.tagger = pickle.load(model_file)
+
+
+    def __call__(self, doc):
+        tokens = [token.lower() for token in doc['tokens'] if token not in doc['tagged']]
+
+        tags = self.classify(tokens)
+
+        for index, token in enumerate(doc['tokens']):
+            if tags[index][1] == 'UNK':
+                continue
+
+            doc['tagged'][doc['tokens'][index]] = {
+                'type': 'grammar',
+                'tags': tags[index][1]
+            }
+
+
+    def classify(self, tokens):
+        return self.tagger.tag(tokens)
+
+
+    def train(self, model_path):
+        corpus = [[(token.lower(), tag) for token, tag in sent] for sent in CORPUS]
+
+        tagger = UnigramTagger(corpus, backoff=DefaultTagger('UNK'))
+
+        with open(model_path, "wb") as model_file:
+            pickle.dump(tagger, model_file)

--- a/nlp/SQLGrammarCorpus.py
+++ b/nlp/SQLGrammarCorpus.py
@@ -1,0 +1,189 @@
+"""
+Corpus for SQL Grammar
+"""
+CORPUS = [
+    [
+        ('Return', 'SELECT'),
+        ('all', "LIMIT"),
+        ('sections', "UNK"),
+        ('.', 'IGN')
+    ],
+    [
+        ('List', 'SELECT'),
+        ('some', "LIMIT"),
+        ('sections', "UNK"),
+        ('.', 'IGN')
+    ],
+    [
+        ('Find', 'SELECT'),
+        ('all', "LIMIT"),
+        ('sections', "UNK"),
+        ('.', 'IGN')
+    ],
+    [
+        ('How', 'SELECT'),
+        ('many', "COUNT"),
+        ('sections', "UNK"),
+        ('are', "IGN"),
+        ('there', "IGN"),
+        ('?', 'IGN')
+    ],
+    [
+        ('Give', 'SELECT'),
+        ('me', "IGN"),
+        ('several', "LIMIT"),
+        ('sections', "UNK"),
+        ('.', 'IGN')
+    ],
+    [
+        ('Find', 'SELECT'),
+        ('a', "LIMIT"),
+        ('section', "UNK"),
+        ('.', 'IGN')
+    ],
+    [
+        ('Find', 'SELECT'),
+        ('1', "LIMIT"),
+        ('section', "UNK"),
+        ('.', 'IGN')
+    ],
+    [
+        ('Find', 'SELECT'),
+        ('2', "LIMIT"),
+        ('sections', "UNK"),
+        ('.', 'IGN')
+    ],
+    [
+        ('Find', 'SELECT'),
+        ('3', "LIMIT"),
+        ('sections', "UNK"),
+        ('.', 'IGN')
+    ],
+    [
+        ('Find', 'SELECT'),
+        ('4', "LIMIT"),
+        ('sections', "UNK"),
+        ('.', 'IGN')
+    ],
+    [
+        ('Find', 'SELECT'),
+        ('5', "LIMIT"),
+        ('sections', "UNK"),
+        ('.', 'IGN')
+    ],
+    [
+        ('Find', 'SELECT'),
+        ('6', "LIMIT"),
+        ('sections', "UNK"),
+        ('.', 'IGN')
+    ],
+    [
+        ('Find', 'SELECT'),
+        ('7', "LIMIT"),
+        ('sections', "UNK"),
+        ('.', 'IGN')
+    ],
+    [
+        ('Find', 'SELECT'),
+        ('8', "LIMIT"),
+        ('sections', "UNK"),
+        ('.', 'IGN')
+    ],
+    [
+        ('Find', 'SELECT'),
+        ('9', "LIMIT"),
+        ('sections', "UNK"),
+        ('.', 'IGN')
+    ],
+    [
+        ('Find', 'SELECT'),
+        ('10', "LIMIT"),
+        ('sections', "UNK"),
+        ('.', 'IGN')
+    ],
+    [
+        ('Find', 'SELECT'),
+        ('one', "LIMIT"),
+        ('section', "UNK"),
+        ('.', 'IGN')
+    ],
+    [
+        ('Find', 'SELECT'),
+        ('two', "LIMIT"),
+        ('sections', "UNK"),
+        ('.', 'IGN')
+    ],
+    [
+        ('Find', 'SELECT'),
+        ('three', "LIMIT"),
+        ('sections', "UNK"),
+        ('.', 'IGN')
+    ],
+    [
+        ('Find', 'SELECT'),
+        ('four', "LIMIT"),
+        ('sections', "UNK"),
+        ('.', 'IGN')
+    ],
+    [
+        ('Find', 'SELECT'),
+        ('five', "LIMIT"),
+        ('sections', "UNK"),
+        ('.', 'IGN')
+    ],
+    [
+        ('Find', 'SELECT'),
+        ('six', "LIMIT"),
+        ('sections', "UNK"),
+        ('.', 'IGN')
+    ],
+    [
+        ('Find', 'SELECT'),
+        ('seven', "LIMIT"),
+        ('sections', "UNK"),
+        ('.', 'IGN')
+    ],
+    [
+        ('Find', 'SELECT'),
+        ('eight', "LIMIT"),
+        ('sections', "UNK"),
+        ('.', 'IGN')
+    ],
+    [
+        ('Find', 'SELECT'),
+        ('nine', "LIMIT"),
+        ('sections', "UNK"),
+        ('.', 'IGN')
+    ],
+    [
+        ('Find', 'SELECT'),
+        ('ten', "LIMIT"),
+        ('sections', "UNK"),
+        ('.', 'IGN')
+    ],
+    [
+        ('Find', 'SELECT'),
+        ('a', 'IGN'),
+        ('few', "LIMIT"),
+        ('sections', "UNK"),
+        ('.', 'IGN')
+    ],
+    [
+        ('What', 'SELECT'),
+        ("'s", 'IGN'),
+        ('the', 'IGN'),
+        ('count', "COUNT"),
+        ('of', 'IGN'),
+        ('sections', "UNK"),
+        ('?', 'IGN')
+    ],
+    [
+        ('What', 'SELECT'),
+        ("'s", 'IGN'),
+        ('the', 'IGN'),
+        ('number', "COUNT"),
+        ('of', 'IGN'),
+        ('sections', "UNK"),
+        ('?', 'IGN')
+    ]
+]

--- a/nlp/__init__.py
+++ b/nlp/__init__.py
@@ -4,3 +4,4 @@ from nlp.Tokenizer import Tokenizer
 from nlp.DBSchemaClassifier import DBSchemaClassifier
 from nlp.DBCorpusClassifier import DBCorpusClassifier
 from nlp.DBCorpusGenerator import DBCorpusGenerator
+from nlp.SQLGrammarClassifier import SQLGrammarClassifier


### PR DESCRIPTION
Another method to tag the basic sql grammar in the questions/sentences. I discussed this with @cfnyu and it accomplishes a similar goal to his regex technique but uses NLTK.

It's basically a lookup tagger. If something is not being tagged, we need to add to `SQLGrammarCorpus.py`.

It's tagging the basic SQL grammar, `select`, `count`, `limit`, etc. 
Unknown tokens or tokens to be tagged in a later classifier are tagged `UNK`.
Tokens that should be ignored going forward (and in the node generator) are tagged as `IGN`.